### PR TITLE
fix: add the output directory if does not exist before

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -37,6 +37,9 @@ testsets.forEach(([testsetDir, lapisPort, siloPort]) => {
     const dataDir = path.join(testsetDir, 'data');
     const queriesDir = path.join(testsetDir, 'queries');
     const outputDir = path.join(testsetDir, 'output');
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir);
+    }
     const dockerComposeFile = 'docker-compose.yml';
 
     const dockerComposeEnv = `LAPIS_TAG=latest SILO_TAG=latest \


### PR DESCRIPTION
resolves #8 

There was a missing step to create the output dirs in folders if they do not exist yet.

These folders will be used by silo preprocessing for writing of their processed data. They will not be deleted afterwards.