### PR TITLE
Fix of the race condition in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,13 @@ services:
               source: ${TESTSET_DATA_FOLDER}/reference_genomes.json
               target: /workspace/reference_genomes.json
               read_only: true
+        healthcheck: # TODO(https://github.com/GenSpectrum/LAPIS-SILO-e2e/issues/32) Remove at some point
+          test: ["CMD-SHELL",
+            "wget -qO- http://localhost:8080/sample/aggregated | grep -o '\"count\":[0-9]*' | sed 's/[^0-9]//g' | xargs test 0 -ne || exit 1"]
+          interval: 2s
+          timeout: 5s
+          retries: 10
+
 
     silo:
         image: ghcr.io/genspectrum/lapis-silo:${SILO_TAG}

--- a/test.ts
+++ b/test.ts
@@ -56,7 +56,7 @@ testsets.map((testSuite) => {
     function dockerComposeUp() {
         console.log(`Starting Docker Compose for ${testSuite.path}...`);
 
-        const dockerComposeUpCommand = `${dockerComposeEnv} docker compose --project-name ${testName} --progress=plain up --no-recreate --detach --wait && sleep 4`;
+        const dockerComposeUpCommand = `${dockerComposeEnv} docker compose --project-name ${testName} --progress=plain up --no-recreate --detach --wait`;
 
         console.log(dockerComposeUpCommand);
         execSync(dockerComposeUpCommand, { stdio: 'inherit' });
@@ -65,9 +65,7 @@ testsets.map((testSuite) => {
     function dockerComposeDown() {
         console.log(`Stopping Docker Compose for ${testSuite.path}...`);
 
-        // Add the sleep 1 because it takes some time until the port is available again.
-        // This might be relevant when running vitest with auto restart
-        const dockerComposeDownCommand = `docker compose -p ${testName} --progress=plain down && sleep 1`;
+        const dockerComposeDownCommand = `docker compose -p ${testName} --progress=plain down`;
 
         console.log(dockerComposeDownCommand);
         execSync(dockerComposeDownCommand, { stdio: 'inherit' });


### PR DESCRIPTION
resolves #17 

The race condition is outlined in more detail in https://github.com/GenSpectrum/LAPIS/issues/941

This leads to flaky tests which should hopefully be finally fixed by this PR. The PR also gets rid of the added `sleep` commands, which were introduced as a mostly-functioning work-around.